### PR TITLE
style tweaks | regex tweaks

### DIFF
--- a/lib/inc/css/clipit-styles.css
+++ b/lib/inc/css/clipit-styles.css
@@ -4,6 +4,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   grid-gap: 2em;
+  justify-items: center;
   font-size: 16px;
   max-width: 1100px;
   margin: 0 auto;
@@ -23,8 +24,10 @@
   border: 1px solid #cccccc;
   padding: 1em;
   border-radius: 0.5em;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12),
+    0 3px 1px -2px rgba(0, 0, 0, 0.2);
   background-color: #fff;
+  max-width: 550px;
 }
 
 .clipit-coupon--single {

--- a/lib/templates/parts/coupon-title.php
+++ b/lib/templates/parts/coupon-title.php
@@ -3,7 +3,7 @@ $raw_title = get_the_title();
 $title = $raw_title;
 $title_accent = '';
 // preg_match('/^((.*?(free|off|[\$\%0-9\.]+)))/i', $raw_title, $title_matches);
-preg_match('/^.*([\$\%0-9\,\.]+|free(?(?=\s))|off(?(?=\s)))/i', $raw_title, $title_matches);
+preg_match('/^.*([\$\%0-9\,]+|free(?(?=\s))|off(?(?=\s)))/i', $raw_title, $title_matches);
 if (!empty($title_matches[0])) {
     $title = trim(str_replace($title_matches[0], '', $raw_title));
     $title_accent = $title_matches[0];

--- a/main.php
+++ b/main.php
@@ -3,7 +3,7 @@
 Plugin Name: ClipIt Coupons
 Plugin URI: http://leadsnearby.com
 Description: ClipIt Coupons is a basic but powerful plugin that uses to create, upload and preview coupons for your visitors to print, view or use directly on your website or blog. With a few words and and even fewer clicks you will be on your way to displaying awesome coupons on your website or blog.
-Version: 2.2.12
+Version: 2.2.2
 Author: LeadsNearby
 Author URI: http://leadsnearby.com
 License: GPLv2


### PR DESCRIPTION
- Fix Coupons styles so that individual coupons never expand beyond 550px and always center themselves in the row when there aren't enough coupons to fill it up.
- Tweaked the coupon title regex to not match periods.  Previously when a period was at the end of the title, it would match and bold the whole coupon title.  No longer.